### PR TITLE
Support -webkit- prefixes and repeating gradients

### DIFF
--- a/gradient_inspector.js
+++ b/gradient_inspector.js
@@ -35,17 +35,14 @@ function displayResult(result) {
 
 
 function parseDefinitions(literalDefinitions) {
-  var rules = literalDefinitions.split(/\w+\-gradient/),
-    rulesTypes = literalDefinitions.match(/(\w+)\-gradient/g),
-    layers = [];
+  var rules = literalDefinitions.split(/([-\w]+\-gradient)/),
+    layers = [],
+    layer, i, ii;
 
-  rules.forEach(function(layer, i) {
-    if (layer !== '') {
-      layer = layer.replace(/\, *$/, '')
-      layerDefinition = rulesTypes[i - 1] + layer;
-      layers.push(layerDefinition);
-    }
-  });
+  for (i = 1, ii = rules.length; i < ii; i += 2) {
+    layer = rules[i + 1].replace(/\, *$/, '');
+    layers.push(rules[i] + layer);
+  }
 
   return layers;
 }

--- a/test/development.html
+++ b/test/development.html
@@ -28,6 +28,7 @@
         border-radius: 50%;
         background-color: #f3e2c3;
         background-image:
+          -webkit-linear-gradient(90deg, transparent 0%, rgba(243, 226, 195, 0.6) 100%),
           linear-gradient(to bottom, transparent 0px, rgba(1,1,1,0) 128px, #f3e2c3 128px, #f3e2c3 100%),
           radial-gradient(circle at 87.23px 134px, #f3e2c3 11px, transparent 11px),
           radial-gradient(circle at 87px 129px, #000 12px, transparent 12px),
@@ -42,7 +43,8 @@
           linear-gradient(51deg, transparent 0px, transparent 153px, #000 153px),
           radial-gradient(circle at 170px 96px, #f3e2c3 68px, transparent 11px),
           radial-gradient(circle at 191px 19px, #000 114px, transparent 11px),
-          linear-gradient(-31deg, transparent 0px, transparent 170px, #000 170px);
+          linear-gradient(-31deg, transparent 0px, transparent 170px, #000 170px),
+          repeating-linear-gradient(to right, #f3e2c3 20%, #e2d1b2 30%, #f3e2c3 40%);
       }
     </style>
   </head>


### PR DESCRIPTION
First of all, thanks for making this, it's already come in very handy.

When I used it on some old sites I'd written, I noticed it didn't handle `-webkit-` prefixed gradients at all. When I dug into the code I realised it also wouldn't handle `repeating-linear-gradient` either, due to the regular expression used.

This PR fixes up the regex and adds a couple of extra gradient syntaxes to the test page.

Cheers,
Gil

PS. Having written devtools extensions and also struggled with the dev/test cycle, I think the method you used in `test/development.html` to speed up development is genius! I'm going to shamelessly steal it for my own projects. ;)
